### PR TITLE
Test case for counter cache bug

### DIFF
--- a/spec/cash/calculations_spec.rb
+++ b/spec/cash/calculations_spec.rb
@@ -36,6 +36,17 @@ module Cash
               mock(Story.connection).execute.never
               story.characters.count(:all, :conditions => { :name => name }).should == characters.size
             end
+
+            it 'has correct counter cache' do
+              story = Story.create!
+              characters = [story.characters.create!(:name => name = 'name'), story.characters.create!(:name => name)]
+              $memcache.flush_all
+              story.characters.find(:all, :conditions => { :name => name }) == characters
+              story.characters.count(:all, :conditions => { :name => name }).should == characters.size
+              story.characters.find(:all, :conditions => { :name => name }) == characters
+              mock(Story.connection).execute.never
+              story.characters.count(:all, :conditions => { :name => name }).should == characters.size
+            end
           end
         end
       end


### PR DESCRIPTION
The second find would call find_from_keys_without_cache and results.each{|x| x.add_to_caches} which would cause unnecessary counter increment. Thanks a lot for maintaining this gem!
