### PR TITLE
Memcached ActiveSupport::Duration vs time_t error

### DIFF
--- a/lib/mem_cached_support_store.rb
+++ b/lib/mem_cached_support_store.rb
@@ -126,7 +126,7 @@ require 'memcached'
 
       private
         def expires_in(options)
-          (options && options[:expires_in]) || 0
+          (options && options[:expires_in] && options[:expires_in].to_i) || 0
         end
 
         def marshal?(options)


### PR DESCRIPTION
Newer versions of memcached error if expires_in isn't cast as a plain integer.  ActiveSupport::Duration types provided by 10.minutes, etc, are no good.
