### PR TITLE
When cache money is off, memcache is still enabled

### DIFF
--- a/lib/cache_money.rb
+++ b/lib/cache_money.rb
@@ -24,7 +24,7 @@ require 'cash/util/marshal'
 
 class ActiveRecord::Base
   def self.is_cached(options = {})
-    if options == false
+    if (options == false || options[:repository].nil?)
       include NoCash
     else
       options.assert_valid_keys(:ttl, :repository, :version)

--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,6 +1,19 @@
 yml = YAML.load(IO.read(File.join(RAILS_ROOT, "config", "memcached.yml")))
 memcache_config = yml[RAILS_ENV]
-memcache_config.symbolize_keys! if memcache_config.respond_to?(:symbolize_keys!)
+
+if memcache_config
+  memcache_config.symbolize_keys! if memcache_config.respond_to?(:symbolize_keys!)
+
+  memcache_config[:logger] = Rails.logger
+  memcache_servers = 
+    case memcache_config[:servers].class.to_s
+      when "String"; memcache_config[:servers].gsub(' ', '').split(',')
+      when "Array"; memcache_config[:servers]
+    end
+  Rails.logger.info '$memcache enabled.'
+  $memcache = MemcachedWrapper.new(memcache_servers, memcache_config)
+end
+  
 
 if defined?(DISABLE_CACHE_MONEY) || ENV['DISABLE_CACHE_MONEY'] == 'true' || memcache_config.nil? || memcache_config[:cache_money] != true
   Rails.logger.info 'cache-money disabled'
@@ -12,20 +25,7 @@ else
   Rails.logger.info 'cache-money enabled'
   require 'cache_money'
 
-  memcache_config[:logger] = Rails.logger
-  memcache_servers = 
-    case memcache_config[:servers].class.to_s
-      when "String"; memcache_config[:servers].gsub(' ', '').split(',')
-      when "Array"; memcache_config[:servers]
-    end
-  $memcache = MemcachedWrapper.new(memcache_servers, memcache_config)
-
-  #ActionController::Base.cache_store = :cache_money_mem_cache_store
   ActionController::Base.session_options[:cache] = $memcache if memcache_config[:sessions]
-  #silence_warnings {
-  #  Object.const_set "RAILS_CACHE", ActiveSupport::Cache.lookup_store(:cache_money_mem_cache_store)
-  #}
-
   $local = Cash::Local.new($memcache)
   $lock  = Cash::Lock.new($memcache)
   $cache = Cash::Transactional.new($local, $lock)


### PR DESCRIPTION
This is for the issue number 19 (I could not find a way to attach this to the issue itself.)

https://github.com/ngmoco/cache-money/issues/19

Have a look and see if this works.
