### PR TITLE
Fix Cash::Mock#get with multiple keys / #set without a ttl

### DIFF
--- a/lib/cash/mock.rb
+++ b/lib/cash/mock.rb
@@ -20,7 +20,7 @@ module Cash
           @value = Marshal.dump(value)
         end
         
-        if ttl.zero?
+        if ttl.nil? || ttl.zero?
           @ttl = self.class.default_ttl
         else
           @ttl = ttl
@@ -68,18 +68,22 @@ module Cash
     end
 
     def get(key, raw = false)
-      log "< get #{key}"
-      unless self.has_unexpired_key?(key)
-        log('> END')
-        return nil
-      end
-      
-      log("> sending key #{key}")
-      log('> END')
-      if raw
-        self[key].value
+      if key.is_a?(Array)
+        get_multi(*key)
       else
-        self[key].unmarshal
+        log "< get #{key}"
+        unless self.has_unexpired_key?(key)
+          log('> END')
+          return nil
+        end
+        
+        log("> sending key #{key}")
+        log('> END')
+        if raw
+          self[key].value
+        else
+          self[key].unmarshal
+        end
       end
     end
     

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,12 @@ Spec::Runner.configure do |config|
       require 'fakeredis'
       $memcache = Cash::Adapter::Redis.new(FakeRedis::Redis.new(),
         :default_ttl => 1.minute.to_i)
-      
+    when 'mock'
+      # Test with Mock client
+      require 'cash/adapter/memcache_client'
+      require 'cash/mock'
+      $memcache = Cash::Adapter::MemcacheClient.new(Cash::Mock.new(),
+        :default_ttl => 1.minute.to_i)
     else
       require 'cash/adapter/memcached'
       # Test with memcached client


### PR DESCRIPTION
Fix Cash::Mock#get with multiple keys / #set without a ttl
Edit
I added the ability to test the Cash::Mock implementation via the ADAPTER hook. This revealed a few issues with the implementation. Specifically:
- When #get is invoked on Cash::Mock with an array of keys, it fails to do a multi-get
- When #set is invoked with a nil ttl, Cash::Mock::CacheEntry fails to fall back to the default

This changeset also fixes those issues.
