### PR TITLE
Fix method definition for Cash::Mock#get_multi

### DIFF
--- a/lib/cash/mock.rb
+++ b/lib/cash/mock.rb
@@ -57,7 +57,7 @@ module Cash
       @logging = false
     end
     
-    def get_multi(keys)
+    def get_multi(*keys)
       slice(*keys).collect { |k,v| [k, v.unmarshal] }.to_hash_without_nils
     end
 


### PR DESCRIPTION
- keys are supplied to get_multi as *keys not as a single array of
  keys
