### PR TITLE
Add license to gemspec

### DIFF
--- a/ngmoco-cache-money.gemspec
+++ b/ngmoco-cache-money.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     "init.rb"
   ]
   s.homepage = %q{http://github.com/ngmoco/cache-money}
+  s.license = "Apache 2.0"
   s.require_paths = ["lib"]
   s.summary = %q{Write-through and Read-through Cacheing for ActiveRecord}
   s.test_files = Dir[


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
